### PR TITLE
Add experimental 'Play vs Gemini' game mode

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,12 @@
+{
+    "version": "0.0.1",
+    "configurations": [
+        {
+            "name": "client",
+            "runtimeExecutable": "npm",
+            "runtimeArgs": ["start", "-w", "client", "--", "--port", "5199", "--no-open"],
+            "port": 5199,
+            "autoPort": false
+        }
+    ]
+}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,7 @@ import "./App.css";
 import { AuthProvider } from "./contexts/AuthContext";
 import { GameClientContextProvider } from "./contexts/GameClientContext";
 import { GameEngineContextProvider } from "./contexts/GameEngineContext";
+import { GeminiSettingsContextProvider } from "./gemini/GeminiSettingsContext";
 import { GameScreenSelector } from "./GameScreenSelector";
 
 const SettingsIcon = styled.div`
@@ -17,10 +18,12 @@ function App() {
             <AuthProvider>
                 <GameEngineContextProvider>
                     <GameClientContextProvider>
-                        <>
-                            <SettingsIcon>⚙️</SettingsIcon>
-                            <GameScreenSelector />
-                        </>
+                        <GeminiSettingsContextProvider>
+                            <>
+                                <SettingsIcon>⚙️</SettingsIcon>
+                                <GameScreenSelector />
+                            </>
+                        </GeminiSettingsContextProvider>
                     </GameClientContextProvider>
                 </GameEngineContextProvider>
             </AuthProvider>

--- a/client/src/GameMode.ts
+++ b/client/src/GameMode.ts
@@ -1,5 +1,11 @@
 export enum GameMode {
     VS_BOT = "vs_bot",
+    VS_GEMINI = "vs_gemini",
     VS_PLAYER_OFFLINE = "vs_player_offline",
     VS_PLAYER_ONLINE = "vs_player_online",
+}
+
+/** Modes where the opponent is controlled by the computer (bot or AI model) */
+export function isVsAiMode(mode: GameMode | null): boolean {
+    return mode === GameMode.VS_BOT || mode === GameMode.VS_GEMINI;
 }

--- a/client/src/GameScreenSelector.tsx
+++ b/client/src/GameScreenSelector.tsx
@@ -5,6 +5,8 @@ import { PlayerSelectionScreen } from "./menus/PlayerSelectionScreen";
 import { ModeSelectionScreen } from "./menus/ModeSelectionScreen";
 import { GameMode } from "./GameMode";
 import OnlineModeScreenSelector from "./OnlineModeScreenSelector";
+import { GeminiOpponent } from "./gemini/GeminiOpponent";
+import { GeminiSettingsPanel } from "./gemini/GeminiSettingsPanel";
 
 export const GameScreenSelector = () => {
     const gameClientContext = useContext(GameClientContext);
@@ -22,6 +24,20 @@ export const GameScreenSelector = () => {
 
     if (mode === GameMode.VS_PLAYER_ONLINE) {
         return <OnlineModeScreenSelector />;
+    }
+
+    if (mode === GameMode.VS_GEMINI) {
+        return (
+            <>
+                <GeminiSettingsPanel />
+                <GeminiOpponent />
+                {gameClientContext.playerSelection === null ? (
+                    <PlayerSelectionScreen mode={mode} />
+                ) : (
+                    <Board />
+                )}
+            </>
+        );
     }
 
     if (

--- a/client/src/board/Tile.tsx
+++ b/client/src/board/Tile.tsx
@@ -13,7 +13,7 @@ import { GameClientContext } from "../contexts/GameClientContext";
 import { GameEngineContext } from "../contexts/GameEngineContext";
 import { AvailableMoveDestination } from "./AvailableMoveDestination";
 import { settings } from "../settings";
-import { GameMode } from "../GameMode";
+import { GameMode, isVsAiMode } from "../GameMode";
 
 const TileBackground = styled.div<{ $color: string }>`
     position: relative;
@@ -50,7 +50,7 @@ export const Tile = ({ piece, tileColor, fileIndex, tileIndex }: TileProps) => {
 
     const onClick = useCallback(() => {
         if (
-            gameClientContext.gameMode === GameMode.VS_BOT &&
+            isVsAiMode(gameClientContext.gameMode) &&
             gameEngineContext.currentPlayer !==
             gameClientContext.playerSelection
         ) {
@@ -60,7 +60,7 @@ export const Tile = ({ piece, tileColor, fileIndex, tileIndex }: TileProps) => {
         const isEmptyTile = piece === null;
         const isOwnPieceSelected =
             !isEmptyTile &&
-            ((gameClientContext.gameMode === GameMode.VS_BOT &&
+            ((isVsAiMode(gameClientContext.gameMode) &&
                     piece.player === gameClientContext.playerSelection) ||
                 (gameClientContext.gameMode === GameMode.VS_PLAYER_OFFLINE &&
                     piece.player === gameEngineContext.currentPlayer));

--- a/client/src/contexts/GameEngineContext.tsx
+++ b/client/src/contexts/GameEngineContext.tsx
@@ -9,6 +9,7 @@ export const GameEngineContext = React.createContext<{
     state: GameState;
     board: Board;
     restartGame: () => void;
+    undoLastMove: () => void;
     moveHistory: Move[];
 }>(null as any);
 
@@ -37,6 +38,14 @@ export const GameEngineContextProvider = ({
         syncState();
     }, []);
 
+    // Game doesn't support undoing, so replay all moves except the last one
+    const undoLastMove = useCallback(() => {
+        const previousMoves = game.current.getMoveHistory().slice(0, -1);
+        game.current = new Game();
+        previousMoves.forEach((move) => game.current.move(move));
+        syncState();
+    }, []);
+
     var initial = game.current.getAvailableMovesForPlayer();
 
     const [availableMovesForPlayer, setAvailableMovesForPlayer] =
@@ -60,6 +69,7 @@ export const GameEngineContextProvider = ({
                 board,
                 moveHistory,
                 restartGame,
+                undoLastMove,
             }}
         >
             {children}

--- a/client/src/gemini/GeminiOpponent.tsx
+++ b/client/src/gemini/GeminiOpponent.tsx
@@ -1,0 +1,132 @@
+import { GameState } from "game-engine";
+import { useContext, useEffect, useRef } from "react";
+import { GameClientContext } from "../contexts/GameClientContext";
+import { GameEngineContext } from "../contexts/GameEngineContext";
+import { GameMode } from "../GameMode";
+import { GeminiSettingsContext } from "./GeminiSettingsContext";
+import { requestGeminiMove } from "./requestGeminiMove";
+
+/**
+ * Headless component that plays Gemini's moves. On every Gemini turn it reads
+ * the current settings, sends the board state and the player's last move to
+ * the Gemini API and applies the returned move.
+ */
+export const GeminiOpponent = () => {
+    const { apiKey, elo, model } = useContext(GeminiSettingsContext);
+    const { gameMode, playerSelection } = useContext(GameClientContext);
+    const {
+        availableMovesForPlayer,
+        board,
+        currentPlayer,
+        move,
+        moveHistory,
+        state,
+        undoLastMove,
+    } = useContext(GameEngineContext);
+
+    const requestInProgressRef = useRef(false);
+    // Latest game info, so a resolved request can detect it became stale
+    // (e.g. the game was restarted while waiting for Gemini)
+    const latestTurnRef = useRef({ gameMode, currentPlayer, moveCount: 0 });
+    latestTurnRef.current = {
+        gameMode,
+        currentPlayer,
+        moveCount: moveHistory.length,
+    };
+    // Move count for which the missing-API-key alert was already shown,
+    // to avoid duplicated alerts from double-invoked effects
+    const noApiKeyAlertMoveCountRef = useRef<number | null>(null);
+
+    useEffect(() => {
+        const isGeminiTurn =
+            gameMode === GameMode.VS_GEMINI &&
+            playerSelection !== null &&
+            currentPlayer !== null &&
+            currentPlayer !== playerSelection &&
+            (state === GameState.UNSTARTED ||
+                state === GameState.IN_PROGRESS);
+
+        if (!isGeminiTurn) {
+            noApiKeyAlertMoveCountRef.current = null;
+            return;
+        }
+
+        if (!apiKey) {
+            if (noApiKeyAlertMoveCountRef.current !== moveHistory.length) {
+                noApiKeyAlertMoveCountRef.current = moveHistory.length;
+                window.alert(
+                    "A Gemini API Key is required to play vs Gemini. " +
+                        "Please insert your API Key in the Gemini settings panel.",
+                );
+                if (moveHistory.length > 0) {
+                    undoLastMove();
+                }
+            }
+            return;
+        }
+
+        if (requestInProgressRef.current) {
+            return;
+        }
+        requestInProgressRef.current = true;
+
+        const requestedAtMoveCount = moveHistory.length;
+        const geminiPlayer = currentPlayer;
+
+        requestGeminiMove({
+            apiKey,
+            model,
+            elo,
+            board,
+            player: geminiPlayer,
+            lastMove: moveHistory[moveHistory.length - 1] ?? null,
+            availableMoves: availableMovesForPlayer,
+        })
+            .then((geminiMove) => {
+                const latest = latestTurnRef.current;
+                const isStale =
+                    latest.gameMode !== GameMode.VS_GEMINI ||
+                    latest.currentPlayer !== geminiPlayer ||
+                    latest.moveCount !== requestedAtMoveCount;
+
+                if (!isStale) {
+                    move(geminiMove);
+                }
+            })
+            .catch((error) => {
+                window.alert(
+                    `Gemini could not make a move: ${error.message}` +
+                        (requestedAtMoveCount > 0
+                            ? "\nYour last move has been undone - please try again."
+                            : ""),
+                );
+                const latest = latestTurnRef.current;
+                if (
+                    requestedAtMoveCount > 0 &&
+                    latest.gameMode === GameMode.VS_GEMINI &&
+                    latest.currentPlayer === geminiPlayer &&
+                    latest.moveCount === requestedAtMoveCount
+                ) {
+                    undoLastMove();
+                }
+            })
+            .finally(() => {
+                requestInProgressRef.current = false;
+            });
+    }, [
+        gameMode,
+        playerSelection,
+        currentPlayer,
+        state,
+        apiKey,
+        model,
+        elo,
+        board,
+        moveHistory,
+        availableMovesForPlayer,
+        move,
+        undoLastMove,
+    ]);
+
+    return null;
+};

--- a/client/src/gemini/GeminiSettingsContext.tsx
+++ b/client/src/gemini/GeminiSettingsContext.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from "react";
+import {
+    DEFAULT_GEMINI_ELO,
+    DEFAULT_GEMINI_MODEL,
+    GeminiModel,
+} from "./geminiSettings";
+
+/** Context holding user-provided settings for the "vs Gemini" mode */
+export const GeminiSettingsContext = React.createContext<{
+    apiKey: string;
+    setApiKey: React.Dispatch<React.SetStateAction<string>>;
+    elo: number;
+    setElo: React.Dispatch<React.SetStateAction<number>>;
+    model: GeminiModel;
+    setModel: React.Dispatch<React.SetStateAction<GeminiModel>>;
+}>({} as any);
+
+export const GeminiSettingsContextProvider = ({
+    children,
+}: {
+    children: JSX.Element;
+}) => {
+    const [apiKey, setApiKey] = useState("");
+    const [elo, setElo] = useState(DEFAULT_GEMINI_ELO);
+    const [model, setModel] = useState<GeminiModel>(DEFAULT_GEMINI_MODEL);
+
+    return (
+        <GeminiSettingsContext.Provider
+            value={{ apiKey, setApiKey, elo, setElo, model, setModel }}
+        >
+            {children}
+        </GeminiSettingsContext.Provider>
+    );
+};

--- a/client/src/gemini/GeminiSettingsPanel.tsx
+++ b/client/src/gemini/GeminiSettingsPanel.tsx
@@ -1,0 +1,114 @@
+import { useContext, useState } from "react";
+import styled from "styled-components";
+import { GeminiSettingsContext } from "./GeminiSettingsContext";
+import {
+    GEMINI_MODELS,
+    GeminiModel,
+    MAX_GEMINI_ELO,
+    MIN_GEMINI_ELO,
+} from "./geminiSettings";
+
+const Panel = styled.div`
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 0.8rem;
+    padding: 1rem;
+    width: 260px;
+    background: rgba(20, 20, 30, 0.95);
+    border: 1px solid #2b3a8f;
+    border-radius: 10px;
+    color: #fff;
+    z-index: 100;
+`;
+
+const PanelTitle = styled.div`
+    font-weight: 600;
+    font-size: 1rem;
+`;
+
+const Label = styled.label`
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    font-size: 0.85rem;
+    color: #b3c0f0;
+`;
+
+const ApiKeyInput = styled.input`
+    padding: 0.5em;
+    border-radius: 6px;
+    border: 1px solid #444;
+    background: #15151f;
+    color: #fff;
+    font-size: 0.85rem;
+`;
+
+const ModelSelect = styled.select`
+    padding: 0.5em;
+    border-radius: 6px;
+    border: 1px solid #444;
+    background: #15151f;
+    color: #fff;
+    font-size: 0.85rem;
+`;
+
+export const GeminiSettingsPanel = () => {
+    const { apiKey, setApiKey, elo, setElo, model, setModel } = useContext(
+        GeminiSettingsContext,
+    );
+    // Local draft so the key is only committed on blur/Enter, not per keystroke
+    const [apiKeyDraft, setApiKeyDraft] = useState(apiKey);
+
+    return (
+        <Panel>
+            <PanelTitle>✨ Gemini settings</PanelTitle>
+
+            <Label>
+                Gemini API Key
+                <ApiKeyInput
+                    type="password"
+                    placeholder="Insert your own Gemini API Key"
+                    value={apiKeyDraft}
+                    onChange={(event) => setApiKeyDraft(event.target.value)}
+                    onBlur={() => setApiKey(apiKeyDraft.trim())}
+                    onKeyDown={(event) => {
+                        if (event.key === "Enter") {
+                            setApiKey(apiKeyDraft.trim());
+                        }
+                    }}
+                />
+            </Label>
+
+            <Label>
+                Difficulty (FIDE rating): {elo}
+                <input
+                    type="range"
+                    min={MIN_GEMINI_ELO}
+                    max={MAX_GEMINI_ELO}
+                    step={50}
+                    value={elo}
+                    onChange={(event) => setElo(Number(event.target.value))}
+                />
+            </Label>
+
+            <Label>
+                Model
+                <ModelSelect
+                    value={model}
+                    onChange={(event) =>
+                        setModel(event.target.value as GeminiModel)
+                    }
+                >
+                    {GEMINI_MODELS.map((modelName) => (
+                        <option key={modelName} value={modelName}>
+                            {modelName}
+                        </option>
+                    ))}
+                </ModelSelect>
+            </Label>
+        </Panel>
+    );
+};

--- a/client/src/gemini/buildGeminiRequest.test.ts
+++ b/client/src/gemini/buildGeminiRequest.test.ts
@@ -1,0 +1,88 @@
+import { ChessFile, Game, Move, Player } from "game-engine";
+import {
+    buildGeminiRequestBody,
+    buildSystemPrompt,
+    buildUserPrompt,
+    GEMINI_MOVE_RESPONSE_SCHEMA,
+    GeminiMoveContext,
+} from "./buildGeminiRequest";
+
+describe("buildSystemPrompt", () => {
+    it("includes the player Gemini plays as", () => {
+        expect(buildSystemPrompt(Player.BLACK, 1600)).toContain("BLACK");
+        expect(buildSystemPrompt(Player.WHITE, 1600)).toContain("WHITE");
+    });
+
+    it("includes the requested FIDE rating", () => {
+        const prompt = buildSystemPrompt(Player.BLACK, 2150);
+
+        expect(prompt).toContain("FIDE rating of 2150");
+    });
+
+    it("instructs Gemini to pick a move from the available moves", () => {
+        const prompt = buildSystemPrompt(Player.BLACK, 1600);
+
+        expect(prompt).toContain('"availableMoves"');
+        expect(prompt).toContain("JSON");
+    });
+});
+
+describe("buildUserPrompt and buildGeminiRequestBody", () => {
+    const createContext = (): GeminiMoveContext => {
+        const game = new Game();
+        const lastMove: Move = {
+            from: { file: ChessFile.E, rank: 2 },
+            to: { file: ChessFile.E, rank: 4 },
+        };
+        game.move(lastMove);
+
+        return {
+            player: Player.BLACK,
+            elo: 1800,
+            board: game.getBoard(),
+            lastMove,
+            availableMoves: game.getAvailableMovesForPlayer(),
+        };
+    };
+
+    it("serializes board, last move and available moves as JSON", () => {
+        const context = createContext();
+
+        const payload = JSON.parse(buildUserPrompt(context));
+
+        expect(payload).toEqual({
+            board: context.board,
+            lastMove: context.lastMove,
+            availableMoves: context.availableMoves,
+        });
+    });
+
+    it("builds a request body with system instruction and user content", () => {
+        const context = createContext();
+
+        const body = buildGeminiRequestBody(context) as any;
+
+        expect(body.systemInstruction.parts[0].text).toContain(
+            "FIDE rating of 1800",
+        );
+        expect(body.contents).toHaveLength(1);
+        expect(body.contents[0].role).toBe("user");
+        expect(JSON.parse(body.contents[0].parts[0].text).lastMove).toEqual(
+            context.lastMove,
+        );
+    });
+
+    it("requests structured JSON output matching the Move schema", () => {
+        const body = buildGeminiRequestBody(createContext()) as any;
+
+        expect(body.generationConfig.responseMimeType).toBe(
+            "application/json",
+        );
+        expect(body.generationConfig.responseSchema).toEqual(
+            GEMINI_MOVE_RESPONSE_SCHEMA,
+        );
+        expect(
+            body.generationConfig.responseSchema.required,
+        ).toEqual(["from", "to"]);
+    });
+});

--- a/client/src/gemini/buildGeminiRequest.ts
+++ b/client/src/gemini/buildGeminiRequest.ts
@@ -1,0 +1,95 @@
+import { Board, Move, Player } from "game-engine";
+
+export interface GeminiMoveContext {
+    /** Player Gemini is playing as */
+    player: Player;
+    /** FIDE rating Gemini should play at */
+    elo: number;
+    board: Board;
+    /** Last move played by the human player, or null if Gemini moves first */
+    lastMove: Move | null;
+    /** All legal moves Gemini can play right now */
+    availableMoves: Move[];
+}
+
+/**
+ * Gemini structured output schema (OpenAPI subset) matching
+ * game-engine's Move interface.
+ */
+export const GEMINI_MOVE_RESPONSE_SCHEMA = {
+    type: "OBJECT",
+    properties: {
+        from: {
+            type: "OBJECT",
+            properties: {
+                file: {
+                    type: "STRING",
+                    enum: ["A", "B", "C", "D", "E", "F", "G", "H"],
+                },
+                rank: { type: "INTEGER", minimum: 1, maximum: 8 },
+            },
+            required: ["file", "rank"],
+        },
+        to: {
+            type: "OBJECT",
+            properties: {
+                file: {
+                    type: "STRING",
+                    enum: ["A", "B", "C", "D", "E", "F", "G", "H"],
+                },
+                rank: { type: "INTEGER", minimum: 1, maximum: 8 },
+            },
+            required: ["file", "rank"],
+        },
+        promoteTo: {
+            type: "STRING",
+            enum: ["Q", "R", "B", "N"],
+            nullable: true,
+        },
+    },
+    required: ["from", "to"],
+} as const;
+
+export function buildSystemPrompt(player: Player, elo: number): string {
+    return `You are a chess opponent playing as ${player} in a chess game.
+
+You will receive a JSON payload describing the current game:
+- "board": the current board as an object whose keys are the files "A"-"H". Each value is an array of 8 entries where index 0 is rank 1 and index 7 is rank 8. Each entry is either null (empty square) or a piece object: { "player": "WHITE" | "BLACK", "type": "K" | "Q" | "R" | "B" | "N" | "P" } ("K" = king, "Q" = queen, "R" = rook, "B" = bishop, "N" = knight, "P" = pawn).
+- "lastMove": the last move played by your opponent as { "from": { "file", "rank" }, "to": { "file", "rank" } }, or null if you are making the first move of the game.
+- "availableMoves": the complete list of moves that are legal for you right now.
+
+Rules you must follow strictly:
+1. Respond with a single JSON object only - no commentary, no markdown, no code fences.
+2. The response must have the shape { "from": { "file": "A"-"H", "rank": 1-8 }, "to": { "file": "A"-"H", "rank": 1-8 } }, with an additional "promoteTo" field ("Q", "R", "B" or "N") if and only if the move promotes a pawn.
+3. Your move MUST be one of the entries in "availableMoves" - match its "from" and "to" exactly. Never invent a move that is not in that list.
+4. Castling is represented as the king moving two files; en passant as the capturing pawn's diagonal move. Both appear in "availableMoves" like any other move.
+
+Play with the strength and style of a human chess player with a FIDE rating of ${elo}. Choose the move such a player would most plausibly choose: a low rating means occasional inaccuracies and simple plans, a high rating means strong, principled play. Do not play noticeably stronger or weaker than a typical ${elo}-rated FIDE player.`;
+}
+
+export function buildUserPrompt(context: GeminiMoveContext): string {
+    return JSON.stringify({
+        board: context.board,
+        lastMove: context.lastMove,
+        availableMoves: context.availableMoves,
+    });
+}
+
+/** Builds the body for a Gemini generateContent request */
+export function buildGeminiRequestBody(context: GeminiMoveContext): object {
+    return {
+        systemInstruction: {
+            parts: [{ text: buildSystemPrompt(context.player, context.elo) }],
+        },
+        contents: [
+            {
+                role: "user",
+                parts: [{ text: buildUserPrompt(context) }],
+            },
+        ],
+        generationConfig: {
+            responseMimeType: "application/json",
+            responseSchema: GEMINI_MOVE_RESPONSE_SCHEMA,
+        },
+    };
+}

--- a/client/src/gemini/geminiSettings.ts
+++ b/client/src/gemini/geminiSettings.ts
@@ -1,0 +1,21 @@
+/** Models the user can pick between - from weaker/cheaper to more powerful */
+export const GEMINI_MODELS = [
+    "gemini-2.5-flash-lite",
+    "gemini-2.5-flash",
+    "gemini-2.5-pro",
+] as const;
+
+export type GeminiModel = (typeof GEMINI_MODELS)[number];
+
+export const DEFAULT_GEMINI_MODEL: GeminiModel = "gemini-2.5-flash";
+
+export const MIN_GEMINI_ELO = 1400;
+export const MAX_GEMINI_ELO = 2800;
+/** Roughly the median FIDE rating */
+export const DEFAULT_GEMINI_ELO = 1600;
+
+export interface GeminiSettings {
+    apiKey: string;
+    elo: number;
+    model: GeminiModel;
+}

--- a/client/src/gemini/parseGeminiResponse.test.ts
+++ b/client/src/gemini/parseGeminiResponse.test.ts
@@ -1,0 +1,123 @@
+import {
+    ChessFile,
+    Game,
+    Move,
+    PieceType,
+    PromotionMove,
+    SpecialMoveType,
+} from "game-engine";
+import {
+    GeminiResponseError,
+    parseGeminiMove,
+} from "./parseGeminiResponse";
+
+describe("parseGeminiMove", () => {
+    const availableMoves = new Game().getAvailableMovesForPlayer();
+
+    it("returns the matching available move", () => {
+        const responseText = JSON.stringify({
+            from: { file: "E", rank: 2 },
+            to: { file: "E", rank: 4 },
+        });
+
+        const move = parseGeminiMove(responseText, availableMoves);
+
+        expect(move.from).toEqual({ file: ChessFile.E, rank: 2 });
+        expect(move.to).toEqual({ file: ChessFile.E, rank: 4 });
+        expect(availableMoves).toContain(move);
+    });
+
+    it("throws GeminiResponseError for invalid JSON", () => {
+        expect(() =>
+            parseGeminiMove("e2 to e4", availableMoves),
+        ).toThrow(GeminiResponseError);
+    });
+
+    it("throws GeminiResponseError when positions are malformed", () => {
+        const missingTo = JSON.stringify({ from: { file: "E", rank: 2 } });
+        const invalidFile = JSON.stringify({
+            from: { file: "X", rank: 2 },
+            to: { file: "E", rank: 4 },
+        });
+        const invalidRank = JSON.stringify({
+            from: { file: "E", rank: 2 },
+            to: { file: "E", rank: 9 },
+        });
+
+        expect(() => parseGeminiMove(missingTo, availableMoves)).toThrow(
+            GeminiResponseError,
+        );
+        expect(() => parseGeminiMove(invalidFile, availableMoves)).toThrow(
+            GeminiResponseError,
+        );
+        expect(() => parseGeminiMove(invalidRank, availableMoves)).toThrow(
+            GeminiResponseError,
+        );
+    });
+
+    it("throws GeminiResponseError for a move that is not available", () => {
+        const illegalMove = JSON.stringify({
+            from: { file: "E", rank: 2 },
+            to: { file: "E", rank: 5 },
+        });
+
+        expect(() => parseGeminiMove(illegalMove, availableMoves)).toThrow(
+            GeminiResponseError,
+        );
+    });
+
+    describe("promotions", () => {
+        const promotionMoves: Move[] = [
+            {
+                from: { file: ChessFile.A, rank: 7 },
+                to: { file: ChessFile.A, rank: 8 },
+                type: SpecialMoveType.PROMOTION,
+            } as Move,
+        ];
+
+        it("keeps the promotion piece returned by Gemini", () => {
+            const responseText = JSON.stringify({
+                from: { file: "A", rank: 7 },
+                to: { file: "A", rank: 8 },
+                promoteTo: "N",
+            });
+
+            const move = parseGeminiMove(
+                responseText,
+                promotionMoves,
+            ) as PromotionMove;
+
+            expect(move.type).toBe(SpecialMoveType.PROMOTION);
+            expect(move.promoteTo).toBe(PieceType.KNIGHT);
+        });
+
+        it("defaults to a queen promotion when promoteTo is missing or invalid", () => {
+            const withoutPromoteTo = JSON.stringify({
+                from: { file: "A", rank: 7 },
+                to: { file: "A", rank: 8 },
+            });
+            const withInvalidPromoteTo = JSON.stringify({
+                from: { file: "A", rank: 7 },
+                to: { file: "A", rank: 8 },
+                promoteTo: "K",
+            });
+
+            expect(
+                (
+                    parseGeminiMove(
+                        withoutPromoteTo,
+                        promotionMoves,
+                    ) as PromotionMove
+                ).promoteTo,
+            ).toBe(PieceType.QUEEN);
+            expect(
+                (
+                    parseGeminiMove(
+                        withInvalidPromoteTo,
+                        promotionMoves,
+                    ) as PromotionMove
+                ).promoteTo,
+            ).toBe(PieceType.QUEEN);
+        });
+    });
+});

--- a/client/src/gemini/parseGeminiResponse.ts
+++ b/client/src/gemini/parseGeminiResponse.ts
@@ -1,0 +1,83 @@
+import {
+    arePositionsEqual,
+    ChessFile,
+    Move,
+    PieceType,
+    PromotablePieceType,
+    PromotionMove,
+    SpecialMoveType,
+} from "game-engine";
+
+/** Thrown when Gemini returns something that is not a legal move - safe to retry */
+export class GeminiResponseError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "GeminiResponseError";
+        // keep instanceof working when compiled to ES5
+        Object.setPrototypeOf(this, GeminiResponseError.prototype);
+    }
+}
+
+const PROMOTABLE_PIECE_TYPES: PromotablePieceType[] = [
+    PieceType.QUEEN,
+    PieceType.ROOK,
+    PieceType.BISHOP,
+    PieceType.KNIGHT,
+];
+
+function isValidPosition(position: any): boolean {
+    return (
+        !!position &&
+        Object.values(ChessFile).includes(position.file) &&
+        Number.isInteger(position.rank) &&
+        position.rank >= 1 &&
+        position.rank <= 8
+    );
+}
+
+/**
+ * Parses Gemini's JSON response text into a Move from `availableMoves`.
+ * Returning the matching available move (instead of the raw parsed object)
+ * keeps engine metadata like `isAttacking` and special move types intact.
+ */
+export function parseGeminiMove(
+    responseText: string,
+    availableMoves: Move[],
+): Move {
+    let parsed: any;
+    try {
+        parsed = JSON.parse(responseText);
+    } catch {
+        throw new GeminiResponseError(
+            `Gemini response is not valid JSON: ${responseText}`,
+        );
+    }
+
+    if (!isValidPosition(parsed?.from) || !isValidPosition(parsed?.to)) {
+        throw new GeminiResponseError(
+            `Gemini response is not a valid move: ${responseText}`,
+        );
+    }
+
+    const matchingMove = availableMoves.find(
+        (move) =>
+            arePositionsEqual(move.from, parsed.from) &&
+            arePositionsEqual(move.to, parsed.to),
+    );
+
+    if (!matchingMove) {
+        throw new GeminiResponseError(
+            `Gemini returned an illegal move: ${responseText}`,
+        );
+    }
+
+    if ((matchingMove as PromotionMove).type === SpecialMoveType.PROMOTION) {
+        const promoteTo = PROMOTABLE_PIECE_TYPES.includes(parsed.promoteTo)
+            ? (parsed.promoteTo as PromotablePieceType)
+            : PieceType.QUEEN;
+
+        return { ...matchingMove, promoteTo } as PromotionMove;
+    }
+
+    return matchingMove;
+}

--- a/client/src/gemini/requestGeminiMove.test.ts
+++ b/client/src/gemini/requestGeminiMove.test.ts
@@ -1,0 +1,125 @@
+import { Game, Player } from "game-engine";
+import {
+    GeminiApiError,
+    GeminiMoveRequest,
+    requestGeminiMove,
+} from "./requestGeminiMove";
+import { GeminiResponseError } from "./parseGeminiResponse";
+
+describe("requestGeminiMove", () => {
+    const originalFetch = global.fetch;
+    let fetchMock: jest.Mock;
+
+    const createRequest = (): GeminiMoveRequest => {
+        const game = new Game();
+
+        return {
+            apiKey: "test-api-key",
+            model: "gemini-2.5-flash",
+            elo: 1600,
+            player: Player.WHITE,
+            board: game.getBoard(),
+            lastMove: null,
+            availableMoves: game.getAvailableMovesForPlayer(),
+        };
+    };
+
+    const geminiResponse = (moveJson: object) => ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+            candidates: [
+                {
+                    content: {
+                        parts: [{ text: JSON.stringify(moveJson) }],
+                    },
+                },
+            ],
+        }),
+    });
+
+    const legalMove = {
+        from: { file: "E", rank: 2 },
+        to: { file: "E", rank: 4 },
+    };
+    const illegalMove = {
+        from: { file: "E", rank: 2 },
+        to: { file: "E", rank: 8 },
+    };
+
+    beforeEach(() => {
+        fetchMock = jest.fn();
+        global.fetch = fetchMock as any;
+    });
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+    });
+
+    it("calls the Gemini API with the chosen model and API key and returns the move", async () => {
+        fetchMock.mockResolvedValue(geminiResponse(legalMove));
+
+        const move = await requestGeminiMove(createRequest());
+
+        expect(move.from).toEqual({ file: "E", rank: 2 });
+        expect(move.to).toEqual({ file: "E", rank: 4 });
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const [url, options] = fetchMock.mock.calls[0];
+        expect(url).toBe(
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent",
+        );
+        expect(options.method).toBe("POST");
+        expect(options.headers["x-goog-api-key"]).toBe("test-api-key");
+    });
+
+    it("throws GeminiApiError without retrying when the API call fails", async () => {
+        fetchMock.mockResolvedValue({
+            ok: false,
+            status: 400,
+            json: async () => ({
+                error: { message: "API key not valid" },
+            }),
+        });
+
+        await expect(requestGeminiMove(createRequest())).rejects.toThrow(
+            GeminiApiError,
+        );
+        await expect(
+            requestGeminiMove(createRequest()),
+        ).rejects.toThrow("API key not valid (status 400)");
+        expect(fetchMock).toHaveBeenCalledTimes(2); // once per requestGeminiMove call
+    });
+
+    it("retries when Gemini returns an illegal move and applies the next valid one", async () => {
+        fetchMock
+            .mockResolvedValueOnce(geminiResponse(illegalMove))
+            .mockResolvedValueOnce(geminiResponse(legalMove));
+
+        const move = await requestGeminiMove(createRequest());
+
+        expect(move.to).toEqual({ file: "E", rank: 4 });
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("gives up after 3 attempts of invalid moves", async () => {
+        fetchMock.mockResolvedValue(geminiResponse(illegalMove));
+
+        await expect(requestGeminiMove(createRequest())).rejects.toThrow(
+            GeminiResponseError,
+        );
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    it("throws GeminiResponseError when the response contains no move text", async () => {
+        fetchMock.mockResolvedValue({
+            ok: true,
+            status: 200,
+            json: async () => ({ candidates: [] }),
+        });
+
+        await expect(requestGeminiMove(createRequest())).rejects.toThrow(
+            GeminiResponseError,
+        );
+    });
+});

--- a/client/src/gemini/requestGeminiMove.ts
+++ b/client/src/gemini/requestGeminiMove.ts
@@ -1,0 +1,88 @@
+import { Move } from "game-engine";
+import { buildGeminiRequestBody, GeminiMoveContext } from "./buildGeminiRequest";
+import { GeminiResponseError, parseGeminiMove } from "./parseGeminiResponse";
+import { GeminiModel } from "./geminiSettings";
+
+const GEMINI_API_BASE_URL =
+    "https://generativelanguage.googleapis.com/v1beta/models";
+
+/** How many times we ask Gemini again when it returns an invalid/illegal move */
+const MAX_ATTEMPTS = 3;
+
+/** Thrown when the Gemini API call itself fails (network/auth/quota) - not retried */
+export class GeminiApiError extends Error {
+    constructor(
+        message: string,
+        public status?: number,
+    ) {
+        super(message);
+        this.name = "GeminiApiError";
+        // keep instanceof working when compiled to ES5
+        Object.setPrototypeOf(this, GeminiApiError.prototype);
+    }
+}
+
+export interface GeminiMoveRequest extends GeminiMoveContext {
+    apiKey: string;
+    model: GeminiModel;
+}
+
+async function callGeminiApi(request: GeminiMoveRequest): Promise<string> {
+    const response = await fetch(
+        `${GEMINI_API_BASE_URL}/${request.model}:generateContent`,
+        {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "x-goog-api-key": request.apiKey,
+            },
+            body: JSON.stringify(buildGeminiRequestBody(request)),
+        },
+    );
+
+    const data: any = await response.json().catch(() => null);
+
+    if (!response.ok) {
+        const apiMessage =
+            data?.error?.message || `Gemini API request failed`;
+        throw new GeminiApiError(
+            `${apiMessage} (status ${response.status})`,
+            response.status,
+        );
+    }
+
+    const responseText = data?.candidates?.[0]?.content?.parts?.[0]?.text;
+    if (typeof responseText !== "string") {
+        throw new GeminiResponseError(
+            "Gemini API response contains no move text",
+        );
+    }
+
+    return responseText;
+}
+
+/**
+ * Asks Gemini for the next move. Invalid or illegal moves are retried up to
+ * MAX_ATTEMPTS times; API errors (e.g. invalid key) fail immediately.
+ */
+export async function requestGeminiMove(
+    request: GeminiMoveRequest,
+): Promise<Move> {
+    let lastError: Error = new GeminiResponseError(
+        "Gemini did not return a move",
+    );
+
+    for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+        try {
+            const responseText = await callGeminiApi(request);
+            return parseGeminiMove(responseText, request.availableMoves);
+        } catch (error) {
+            if (!(error instanceof GeminiResponseError)) {
+                throw error;
+            }
+            lastError = error;
+        }
+    }
+
+    throw lastError;
+}

--- a/client/src/menus/ModeSelectionScreen.tsx
+++ b/client/src/menus/ModeSelectionScreen.tsx
@@ -55,6 +55,13 @@ export const ModeSelectionScreen: React.FC<ModeSelectionScreenProps> = ({
         </ModeButton>
 
         <ModeButton
+            $color="radial-gradient(circle at center, #1a2f7a 0%, #000 100%)"
+            onClick={() => onSelect(GameMode.VS_GEMINI)}
+        >
+            ✨ Play vs Gemini
+        </ModeButton>
+
+        <ModeButton
             $color="#6ee7b7"
             onClick={() => onSelect(GameMode.VS_PLAYER_OFFLINE)}
         >

--- a/client/src/popups/handle-game-end.tsx
+++ b/client/src/popups/handle-game-end.tsx
@@ -1,5 +1,5 @@
 import { GameState, Player } from "game-engine";
-import { GameMode } from "../GameMode";
+import { GameMode, isVsAiMode } from "../GameMode";
 import { isDraw } from "game-engine/src/utils";
 
 export function handleGameEnd(
@@ -23,7 +23,7 @@ export function handleGameEnd(
         return alert("Draw by stalemate");
     }
 
-    if (gameMode === GameMode.VS_BOT) {
+    if (isVsAiMode(gameMode)) {
         if (playerSelection === Player.WHITE) {
             if (gameState === GameState.WHITE_WON) {
                 alert("You won");

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,5 +2,5 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  modulePathIgnorePatterns: ["<rootDir>/server/"] // todo - figure out how to run all tests in one jest run
+  modulePathIgnorePatterns: ["<rootDir>/server/", "<rootDir>/game-engine/build/"] // todo - figure out how to run all tests in one jest run
 };


### PR DESCRIPTION
Closes #57

## What

Adds an experimental **✨ Play vs Gemini** game mode where the player plays against the Gemini API.

## How it works

- New `GameMode.VS_GEMINI = "vs_gemini"` and a new `ModeButton` on the `ModeSelectionScreen` with the ✨ sparkles emoji and a black background with a navy-blue radial gradient spreading from the middle of the button.
- Selecting the mode shows a **Gemini settings panel** with:
  - a **Gemini API Key** input (placeholder `Insert your own Gemini API Key`). The key is kept in memory only and read on every request (committed on blur/Enter so partial keys aren't used mid-typing).
  - **Difficulty slider** (FIDE rating 1400–2800, default 1600). The system prompt instructs Gemini to play at the strength/style of a player with that FIDE rating.
  - **Model selector** (`gemini-2.5-flash-lite` / `gemini-2.5-flash` / `gemini-2.5-pro`, default `gemini-2.5-flash`).
- On every Gemini turn, the headless `GeminiOpponent` component sends the current board state, the player's last move and the list of legal moves to `models/{model}:generateContent` (no conversation history). Input is the game-engine's `Board`/`Move` JSON; output uses Gemini structured output (`responseMimeType: application/json` + a `responseSchema` matching the game-engine `Move` interface). The returned move is validated against the legal-move list and applied.
- If the user makes a move while the API key input is empty, a `window.alert` explains that the key is required and the move is **undone** (new `GameEngineContext.undoLastMove`, which replays the move history minus the last move). The same undo happens if the API call fails (e.g. invalid key), so the player can simply retry.
- Invalid/illegal moves returned by Gemini are retried up to 3 times before giving up; API errors fail fast.

## Separation of concerns / tests

All Gemini code lives in `client/src/gemini/`:

| File | Responsibility |
|---|---|
| `buildGeminiRequest.ts` | system prompt, user payload, response schema, request body (pure) |
| `parseGeminiResponse.ts` | parse + validate Gemini's JSON into a legal engine `Move` (pure) |
| `requestGeminiMove.ts` | fetch wrapper with retry policy and error types |
| `GeminiSettingsContext.tsx` / `GeminiSettingsPanel.tsx` | user settings state + UI |
| `GeminiOpponent.tsx` | React glue: triggers a request on Gemini's turn, applies the move, handles stale responses/undo |

17 new unit tests cover prompt building, response parsing (incl. promotions defaulting to queen) and the API client (mocked `fetch`, retry and error paths). They run as part of the root `jest` suite (`jest.config.js` now ignores `game-engine/build/` so the workspace package resolves without a haste collision).

No `.env` needed — the API key is provided by the user at runtime and never persisted.

## Verification

- `npx jest --ci` — 42 suites / 167 tests pass
- `npm run build -w client` passes
- Manually smoke-tested in the browser: mode button + settings panel render, missing-key alert undoes the player's move, and with `fetch` stubbed to a canned Gemini response the full move loop works (player plays e4, "Gemini" answers e5 and it's applied to the board).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
